### PR TITLE
Align M5 entries with trend

### DIFF
--- a/PropEdge BTC EA.mq5
+++ b/PropEdge BTC EA.mq5
@@ -118,7 +118,7 @@ void OnTick()
       return;
 
    int signal = GetCandleSignal();
-   if(signal==1 && IsStrongTrend())
+   if(signal==1 && IsStrongTrend() && CheckBuyConditions())
      {
       double price = SymbolInfoDouble(_Symbol, SYMBOL_ASK);
       double atrH4[1];
@@ -128,7 +128,7 @@ void OnTick()
       if(!SendOrder(price, sl, 0, ORDER_TYPE_BUY))
          Print("Buy order failed");
      }
-   else if(signal==-1 && IsStrongTrend())
+   else if(signal==-1 && IsStrongTrend() && CheckSellConditions())
      {
       double price = SymbolInfoDouble(_Symbol, SYMBOL_BID);
       double atrH4[1];
@@ -251,7 +251,7 @@ bool CheckSpread()
   }
 
 //+------------------------------------------------------------------+
-//| Evaluate buy conditions                                          |
+//| Evaluate buy conditions (trend alignment)                         |
 //+------------------------------------------------------------------+
 bool CheckBuyConditions()
   {
@@ -260,7 +260,7 @@ bool CheckBuyConditions()
   }
 
 //+------------------------------------------------------------------+
-//| Evaluate sell conditions                                         |
+//| Evaluate sell conditions (trend alignment)                        |
 //+------------------------------------------------------------------+
 bool CheckSellConditions()
   {


### PR DESCRIPTION
## Summary
- guard M5 candlestick signals with trend direction checks
- clarify that trend check helpers are used for alignment

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6872b54d245c8328ae1648faa3625d85