### PR TITLE
Add DigitalOcean infra setup

### DIFF
--- a/infra/digitalocean/README.md
+++ b/infra/digitalocean/README.md
@@ -1,0 +1,22 @@
+# DigitalOcean Infrastructure
+
+This directory contains infrastructure configuration for deploying the trading bot on DigitalOcean.
+
+## Terraform
+
+The Terraform configuration in `terraform/` provisions a single droplet. Copy `terraform.tfvars.example` to `terraform.tfvars` and set your DigitalOcean token before running:
+
+```bash
+cd terraform
+terraform init
+terraform plan
+terraform apply
+```
+
+## Ansible
+
+The Ansible playbook in `ansible/` installs basic dependencies and clones the trading bot repository. Update `inventory.ini` with the droplet's IP address and run:
+
+```bash
+ansible-playbook -i inventory.ini setup_bot.yml
+```

--- a/infra/digitalocean/ansible/inventory.ini
+++ b/infra/digitalocean/ansible/inventory.ini
@@ -1,0 +1,3 @@
+[trader]
+# Replace with droplet IP
+droplet ansible_host=1.2.3.4 ansible_user=root

--- a/infra/digitalocean/ansible/setup_bot.yml
+++ b/infra/digitalocean/ansible/setup_bot.yml
@@ -1,0 +1,20 @@
+---
+- hosts: trader
+  become: yes
+  tasks:
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+
+    - name: Install dependencies
+      apt:
+        name:
+          - git
+          - python3-pip
+        state: present
+
+    - name: Clone trading bot repo
+      git:
+        repo: https://github.com/yourusername/yourbot.git
+        dest: /opt/trading-bot
+        version: main

--- a/infra/digitalocean/terraform/main.tf
+++ b/infra/digitalocean/terraform/main.tf
@@ -1,0 +1,12 @@
+provider "digitalocean" {
+  token = var.do_token
+}
+
+resource "digitalocean_droplet" "trading_bot" {
+  name   = "trading-bot"
+  region = var.region
+  size   = "s-1vcpu-1gb"
+  image  = var.image
+
+  tags = ["trader"]
+}

--- a/infra/digitalocean/terraform/outputs.tf
+++ b/infra/digitalocean/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "droplet_ip" {
+  description = "Public IPv4 of the trading bot droplet"
+  value       = digitalocean_droplet.trading_bot.ipv4_address
+}

--- a/infra/digitalocean/terraform/terraform.tfvars.example
+++ b/infra/digitalocean/terraform/terraform.tfvars.example
@@ -1,0 +1,6 @@
+# DigitalOcean personal access token
+do_token = "your-token-here"
+
+# Optional overrides
+#region = "nyc3"
+#image  = "ubuntu-22-04-x64"

--- a/infra/digitalocean/terraform/variables.tf
+++ b/infra/digitalocean/terraform/variables.tf
@@ -1,0 +1,16 @@
+variable "do_token" {
+  type        = string
+  description = "DigitalOcean API token"
+}
+
+variable "region" {
+  type        = string
+  default     = "nyc3"
+  description = "Region for the droplet"
+}
+
+variable "image" {
+  type        = string
+  default     = "ubuntu-22-04-x64"
+  description = "Droplet image"
+}

--- a/infra/digitalocean/terraform/versions.tf
+++ b/infra/digitalocean/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = ">= 2.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Terraform configs for a DigitalOcean droplet
- include an example tfvars file
- add Ansible inventory and setup playbook
- document DigitalOcean infrastructure

## Testing
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*
- `ansible-playbook --syntax-check setup_bot.yml`

------
https://chatgpt.com/codex/tasks/task_e_687d982b39708328981dac4fe1b4aabf