### PR TITLE
Add local Vagrant environment

### DIFF
--- a/infra/digitalocean/README.md
+++ b/infra/digitalocean/README.md
@@ -20,3 +20,17 @@ The Ansible playbook in `ansible/` installs basic dependencies and clones the tr
 ```bash
 ansible-playbook -i inventory.ini setup_bot.yml
 ```
+
+## Vagrant
+
+A `Vagrantfile` is provided in `vagrant/` for running the bot locally in a
+virtual machine. Start the VM and connect with:
+
+```bash
+cd vagrant
+vagrant up
+vagrant ssh
+```
+
+Use this environment to experiment before deploying to DigitalOcean. Destroy the
+VM with `vagrant destroy` when finished.

--- a/infra/digitalocean/vagrant/Vagrantfile
+++ b/infra/digitalocean/vagrant/Vagrantfile
@@ -1,0 +1,14 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/jammy64"
+  config.vm.hostname = "trading-bot"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 1024
+    vb.cpus = 1
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update
+    apt-get install -y git python3-pip
+  SHELL
+end


### PR DESCRIPTION
## Summary
- include a Vagrantfile for local testing
- document how to use Vagrant alongside Terraform and Ansible

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d9a9b01c88328904bf0de786f7a83