### PR TITLE
Add Tauri + FastAPI trading bot scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea/
 /.venv/
 /matchtrader-bot.iml
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ The script will initialise MetaTrader 5, fetch market data and execute trades if
 
 ## Desktop App
 
-A cross-platform desktop UI using Tauri and React is provided in the `trading-bot-app` folder. It wraps the FastAPI backend in `backend/main.py` and bundles the existing `prop_firm_bot.py` for execution. Run `./build.sh` inside `trading-bot-app` to build the installer.
+A cross-platform desktop UI using Tauri and React is provided in the `trading-bot-app` folder.  The FastAPI backend simply launches the existing `prop_firm_bot.py` script so all trading logic remains in that file.  Run `./build.sh` inside `trading-bot-app` to build the installer.

--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ Run the trading bot with:
 python prop_firm_bot.py
 ```
 The script will initialise MetaTrader 5, fetch market data and execute trades if signals are generated.
+
+## Desktop App
+
+A cross-platform desktop UI using Tauri and React is provided in the `trading-bot-app` folder. It wraps the FastAPI backend in `backend/main.py` and bundles the existing `prop_firm_bot.py` for execution. Run `./build.sh` inside `trading-bot-app` to build the installer.

--- a/trading-bot-app/backend/main.py
+++ b/trading-bot-app/backend/main.py
@@ -1,0 +1,82 @@
+import subprocess
+from pathlib import Path
+from typing import List
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost", "tauri://localhost"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+BOT_PROCESS: subprocess.Popen | None = None
+LOG_FILE = Path(__file__).parent / "logs" / "trading.log"
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _is_running() -> bool:
+    return BOT_PROCESS is not None and BOT_PROCESS.poll() is None
+
+
+@app.post("/start")
+async def start_bot() -> JSONResponse:
+    """Launch the trading bot."""
+    global BOT_PROCESS
+    if _is_running():
+        return JSONResponse({"running": True})
+    with LOG_FILE.open("a") as f:
+        BOT_PROCESS = subprocess.Popen(
+            ["python", "../../prop_firm_bot.py"],
+            stdout=f,
+            stderr=subprocess.STDOUT,
+        )
+    return JSONResponse({"running": True})
+
+
+@app.post("/stop")
+async def stop_bot() -> JSONResponse:
+    """Stop the trading bot if running."""
+    global BOT_PROCESS
+    if _is_running():
+        BOT_PROCESS.terminate()
+        BOT_PROCESS.wait(timeout=5)
+    BOT_PROCESS = None
+    return JSONResponse({"running": False})
+
+
+@app.get("/status")
+async def status() -> JSONResponse:
+    return JSONResponse({"running": _is_running()})
+
+
+@app.get("/logs")
+async def get_logs() -> JSONResponse:
+    if LOG_FILE.exists():
+        lines: List[str] = LOG_FILE.read_text().splitlines()[-200:]
+    else:
+        lines = []
+    return JSONResponse({"logs": lines})
+
+
+@app.get("/chart-data")
+async def chart_data() -> JSONResponse:
+    """Return placeholder chart data."""
+    # Real implementation would stream prices from exchange
+    if LOG_FILE.exists():
+        timestamps = list(range(0, 10))
+        prices = [i * 100 for i in range(10)]
+    else:
+        timestamps = []
+        prices = []
+    return JSONResponse({"timestamps": timestamps, "prices": prices})
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="127.0.0.1", port=8000)

--- a/trading-bot-app/backend/main.py
+++ b/trading-bot-app/backend/main.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 from pathlib import Path
 from typing import List
 
@@ -15,6 +16,8 @@ app.add_middleware(
 )
 
 BOT_PROCESS: subprocess.Popen | None = None
+ROOT_DIR = Path(__file__).resolve().parents[1]
+BOT_PATH = ROOT_DIR / "prop_firm_bot.py"
 LOG_FILE = Path(__file__).parent / "logs" / "trading.log"
 LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
 
@@ -31,9 +34,10 @@ async def start_bot() -> JSONResponse:
         return JSONResponse({"running": True})
     with LOG_FILE.open("a") as f:
         BOT_PROCESS = subprocess.Popen(
-            ["python", "../../prop_firm_bot.py"],
+            [sys.executable, str(BOT_PATH)],
             stdout=f,
             stderr=subprocess.STDOUT,
+            cwd=str(ROOT_DIR),
         )
     return JSONResponse({"running": True})
 

--- a/trading-bot-app/backend/start_backend.sh
+++ b/trading-bot-app/backend/start_backend.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd "$(dirname "$0")"
-exec uvicorn main:app --host 127.0.0.1 --port 8000
+exec python -m uvicorn main:app --host 127.0.0.1 --port 8000

--- a/trading-bot-app/backend/start_backend.sh
+++ b/trading-bot-app/backend/start_backend.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd "$(dirname "$0")"
+exec uvicorn main:app --host 127.0.0.1 --port 8000

--- a/trading-bot-app/build.sh
+++ b/trading-bot-app/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Build frontend
+cd frontend && npm install && npm run build && cd ..
+# Start backend & tauri build
+cd src-tauri && tauri build && cd ..

--- a/trading-bot-app/frontend/index.html
+++ b/trading-bot-app/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Trading Bot</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/trading-bot-app/frontend/package.json
+++ b/trading-bot-app/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "trading-bot-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "axios": "^1.6.8",
+    "chart.js": "^4.4.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.28",
+    "@types/react-dom": "^18.2.14",
+    "typescript": "^5.3.3",
+    "vite": "^5.2.0",
+    "@vitejs/plugin-react": "^4.0.3"
+  }
+}

--- a/trading-bot-app/frontend/src/HomePage.tsx
+++ b/trading-bot-app/frontend/src/HomePage.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+import { Line } from 'react-chartjs-2'
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  TimeScale,
+} from 'chart.js'
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, TimeScale)
+
+export default function HomePage() {
+  const [running, setRunning] = useState(false)
+  const [prices, setPrices] = useState<number[]>([])
+  const [labels, setLabels] = useState<string[]>([])
+  const [logs, setLogs] = useState<string[]>("")
+
+  const fetchStatus = async () => {
+    const res = await axios.get('/status')
+    setRunning(res.data.running)
+  }
+
+  const fetchLogs = async () => {
+    const res = await axios.get('/logs')
+    setLogs(res.data.logs.join('\n'))
+  }
+
+  const fetchChart = async () => {
+    const res = await axios.get('/chart-data')
+    setPrices(res.data.prices)
+    setLabels(res.data.timestamps)
+  }
+
+  const startBot = async () => {
+    await axios.post('/start')
+    fetchStatus()
+  }
+  const stopBot = async () => {
+    await axios.post('/stop')
+    fetchStatus()
+  }
+
+  useEffect(() => {
+    fetchStatus()
+    const interval = setInterval(() => {
+      fetchLogs()
+      fetchChart()
+      fetchStatus()
+    }, 2000)
+    return () => clearInterval(interval)
+  }, [])
+
+  const data = {
+    labels,
+    datasets: [{
+      label: 'Price',
+      data: prices,
+      borderColor: 'rgb(75, 192, 192)',
+      tension: 0.1,
+    }]
+  }
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Trading Bot</h1>
+      <div>
+        <button onClick={startBot} disabled={running}>Start Bot</button>
+        <button onClick={stopBot} disabled={!running}>Stop Bot</button>
+      </div>
+      <h2>Status: {running ? 'Running' : 'Stopped'}</h2>
+      <div style={{ width: '600px', height: '300px' }}>
+        <Line data={data} />
+      </div>
+      <pre style={{ background: '#111', color: '#0f0', padding: '10px' }}>{logs}</pre>
+    </div>
+  )
+}

--- a/trading-bot-app/frontend/src/main.tsx
+++ b/trading-bot-app/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import HomePage from './HomePage'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <HomePage />
+  </React.StrictMode>
+)

--- a/trading-bot-app/frontend/tsconfig.json
+++ b/trading-bot-app/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/trading-bot-app/frontend/tsconfig.node.json
+++ b/trading-bot-app/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/trading-bot-app/frontend/vite.config.ts
+++ b/trading-bot-app/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+})

--- a/trading-bot-app/shared/config.yaml
+++ b/trading-bot-app/shared/config.yaml
@@ -1,0 +1,5 @@
+bot:
+  symbol: BTCUSD
+  rule_set: ftmo
+logging:
+  file: backend/logs/trading.log

--- a/trading-bot-app/src-tauri/tauri.conf.json
+++ b/trading-bot-app/src-tauri/tauri.conf.json
@@ -1,0 +1,30 @@
+{
+  "package": {
+    "productName": "TradingBot",
+    "version": "0.1.0"
+  },
+  "build": {
+    "beforeBuildCommand": "",
+    "beforeDevCommand": "",
+    "devPath": "../frontend/dist",
+    "distDir": "../frontend/dist"
+  },
+  "tauri": {
+    "bundle": {
+      "active": true,
+      "targets": ["deb", "appimage", "msi"],
+      "identifier": "com.example.tradingbot",
+      "icon": ["icons/icon.png"],
+      "resources": [],
+      "externalBin": ["../backend/start_backend.sh"],
+      "windows": {
+        "certificateThumbprint": null,
+        "digestAlgorithm": "sha256",
+        "timestampUrl": "https://timestamp.digicert.com"
+      }
+    },
+    "security": {
+      "csp": "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline';"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add new cross-platform desktop app scaffold under `trading-bot-app`
- implement FastAPI backend to manage bot execution
- create React frontend with live chart and log viewer
- add Tauri config and build script
- document desktop app usage in README

## Testing
- `python -m py_compile trading-bot-app/backend/main.py`
- `python -m py_compile prop_firm_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_687eaef192f88328971b8cb97650eb40