### PR TITLE
Add Windows build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ The script will initialise MetaTrader 5, fetch market data and execute trades if
 
 ## Desktop App
 
-A cross-platform desktop UI using Tauri and React is provided in the `trading-bot-app` folder.  The FastAPI backend simply launches the existing `prop_firm_bot.py` script so all trading logic remains in that file.  Run `./build.sh` inside `trading-bot-app` to build the installer.
+A cross-platform desktop UI using Tauri and React is provided in the `trading-bot-app` folder.  The FastAPI backend simply launches the existing `prop_firm_bot.py` script so all trading logic remains in that file.  Run `./build.sh` (or `./build.ps1` on Windows) inside `trading-bot-app` to build the installer.

--- a/trading-bot-app/build.ps1
+++ b/trading-bot-app/build.ps1
@@ -1,0 +1,12 @@
+$ErrorActionPreference = 'Stop'
+
+# Build frontend
+Push-Location frontend
+npm install
+npm run build
+Pop-Location
+
+# Start backend & tauri build
+Push-Location src-tauri
+tauri build
+Pop-Location


### PR DESCRIPTION
## Summary
- add a PowerShell build script for Windows
- document new script in the README

## Testing
- `npm install` in `frontend`
- `npm run build` *(fails at first, then after installing `react-chartjs-2` it succeeds)*
- `tauri build` *(fails: `tauri.conf.json` validation errors)*

------
https://chatgpt.com/codex/tasks/task_e_687edb5ec90c83289bd8009882edbec5